### PR TITLE
Don't ignore tar failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,8 @@ RUN apk add --update --no-cache \
     openssl-dev
 ARG Version
 ENV VERSION="$Version"
-# Tar fails without an error in Docker Hub but succeeds on my laptop. For now
-# ignore the error as the build is fine even with it.
 RUN wget "https://github.com/varnish/hitch/archive/${VERSION}.tar.gz" && \
-    tar -vxzf "${VERSION}.tar.gz" || true
+    tar -vxz --no-same-owner --no-same-permissions -f "${VERSION}.tar.gz"
 WORKDIR /hitch-${Version}
 ENV LDFLAGS="--static"
 RUN ./bootstrap && \


### PR DESCRIPTION
When the user is `root` (as is often the case in a container), then
`tar` will try to preserve the ownership and permissions of the files
since it's operating in backup restoration mode. But these are just
source files and you'd actually prefer to ignore the mode in the tarball
as would be done for an unprivileged user. Explicitly pass
`--no-same-owner --no-same-permissions` as is the default for
unprivileged users. This is what `dpkg` and other packaging tools do
when extracting source tarballs.

I didn't test if this actually fixes the issue on Docker Hub, but it is more correct for this use case.